### PR TITLE
Add skip control and more streaming quality presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ cython_debug/
 .cursorindexingignore
 *.txt
 *.json
+yt-dlp.exe
+ffmpeg.exe

--- a/Stream247_GUI.py
+++ b/Stream247_GUI.py
@@ -132,9 +132,10 @@ class StreamConfig:
     audio_bitrate: str = "128k"
     overlay_titles: bool = True
     shuffle: bool = False
-    sleep_between: int = 3
+    sleep_between: int = 0
     fontfile: str = r"C:\Windows\Fonts\arial.ttf"
     title_file: str = "current_title.txt"
+    bumper_path: str = ""
 
     # runtime-selected
     encoder: str = "libx264"
@@ -156,6 +157,7 @@ class StreamWorker(QtCore.QObject):
         super().__init__(parent)
         self.cfg = cfg
         self._stop = threading.Event()
+        self._skip = threading.Event()
         self.ffmpeg_path = find_ffmpeg()
         self.ytdlp_path = find_ytdlp()
         self.ff_proc = None
@@ -190,6 +192,15 @@ class StreamWorker(QtCore.QObject):
                         pass
         finally:
             self.ff_proc = None
+
+    def skip(self):
+        self._skip.set()
+        self.log.emit("[INFO] Skip requested — advancing to next item…")
+        try:
+            if self.ff_proc and self.ff_proc.poll() is None:
+                self.ff_proc.kill()
+        except Exception:
+            pass
 
     # ---------- yt-dlp helpers ----------
     def get_video_ids(self, playlist_url: str) -> List[str]:
@@ -328,7 +339,7 @@ class StreamWorker(QtCore.QObject):
         vurl, aurl = self.get_stream_urls(video_id)
         ff_cmd = self.build_ffmpeg_cmd(vurl, aurl)
         self.log.emit(f"[CMD] ffmpeg: {' '.join(ff_cmd)}")
-
+        self._skip.clear()
         self.ff_proc = subprocess.Popen(
             ff_cmd,
             stdin=None,
@@ -338,10 +349,12 @@ class StreamWorker(QtCore.QObject):
             creationflags=CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
         )
 
-        while self.ff_proc and self.ff_proc.poll() is None and not self._stop.is_set():
+        while self.ff_proc and self.ff_proc.poll() is None and not (
+            self._stop.is_set() or self._skip.is_set()
+        ):
             time.sleep(0.2)
 
-        if self._stop.is_set() and self.ff_proc and self.ff_proc.poll() is None:
+        if (self._stop.is_set() or self._skip.is_set()) and self.ff_proc and self.ff_proc.poll() is None:
             try:
                 self.ff_proc.kill()
             except Exception:
@@ -352,6 +365,43 @@ class StreamWorker(QtCore.QObject):
                 self.ff_proc.wait(timeout=1.0)
         except Exception:
             pass
+
+        self._skip.clear()
+
+    def run_bumper(self):
+        path = self.cfg.bumper_path
+        if not path:
+            return
+        self.log.emit(f"[INFO] Playing bumper: {path}")
+        prev_overlay = self.cfg.overlay_titles
+        self.cfg.overlay_titles = False
+        ff_cmd = self.build_ffmpeg_cmd(path, None)
+        self.cfg.overlay_titles = prev_overlay
+        self.log.emit(f"[CMD] ffmpeg: {' '.join(ff_cmd)}")
+        self._skip.clear()
+        self.ff_proc = subprocess.Popen(
+            ff_cmd,
+            stdin=None,
+            stdout=None,
+            stderr=None,
+            startupinfo=STARTUPINFO,
+            creationflags=CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+        )
+        while self.ff_proc and self.ff_proc.poll() is None and not (
+            self._stop.is_set() or self._skip.is_set()
+        ):
+            time.sleep(0.2)
+        if (self._stop.is_set() or self._skip.is_set()) and self.ff_proc and self.ff_proc.poll() is None:
+            try:
+                self.ff_proc.kill()
+            except Exception:
+                pass
+        try:
+            if self.ff_proc:
+                self.ff_proc.wait(timeout=1.0)
+        except Exception:
+            pass
+        self._skip.clear()
 
     # ---------- main loop ----------
     @QtCore.Slot()
@@ -401,12 +451,10 @@ class StreamWorker(QtCore.QObject):
 
                     if self._stop.is_set():
                         break
-                    if self.cfg.sleep_between > 0:
-                        self.log.emit(f"[INFO] Sleeping {self.cfg.sleep_between}s…")
-                        for _ in range(self.cfg.sleep_between):
-                            if self._stop.is_set():
-                                break
-                            time.sleep(1)
+                    if self.cfg.bumper_path:
+                        self.run_bumper()
+                    if self._stop.is_set():
+                        break
 
                 if self._stop.is_set():
                     break
@@ -467,9 +515,12 @@ class MainWindow(QtWidgets.QWidget):
         self.key_edit.setEchoMode(QtWidgets.QLineEdit.Password)
 
         self.res_combo = QtWidgets.QComboBox()
-        self.res_combo.addItems(["720p30", "720p60", "1080p30"])
+        self.res_combo.addItems(["480p30", "480p60", "720p30", "720p60", "1080p30", "1080p60"])
+        self.res_combo.setCurrentText("720p30")
         self.bitrate_edit = QtWidgets.QLineEdit("2300k")
         self.bufsize_edit = QtWidgets.QLineEdit("4600k")
+        self.bumper_edit = QtWidgets.QLineEdit("")
+        self.browse_btn = QtWidgets.QPushButton("Browse…")
 
         self.overlay_chk = QtWidgets.QCheckBox("Overlay current VOD title")
         self.overlay_chk.setChecked(True)
@@ -486,6 +537,8 @@ class MainWindow(QtWidgets.QWidget):
         self.start_btn = QtWidgets.QPushButton("Start Stream")
         self.stop_btn = QtWidgets.QPushButton("Stop Stream")
         self.stop_btn.setEnabled(False)
+        self.skip_btn = QtWidgets.QPushButton("Skip Video")
+        self.skip_btn.setEnabled(False)
 
         # Layout
         form = QtWidgets.QGridLayout()
@@ -502,6 +555,10 @@ class MainWindow(QtWidgets.QWidget):
         form.addWidget(QtWidgets.QLabel("Buffer Size"), 3, 2)
         form.addWidget(self.bufsize_edit, 3, 3)
 
+        form.addWidget(QtWidgets.QLabel("Bumper Video"), 4, 0)
+        form.addWidget(self.bumper_edit, 4, 1, 1, 2)
+        form.addWidget(self.browse_btn, 4, 3)
+
         toggles = QtWidgets.QHBoxLayout()
         toggles.addWidget(self.overlay_chk)
         toggles.addWidget(self.shuffle_chk)
@@ -515,6 +572,7 @@ class MainWindow(QtWidgets.QWidget):
         btns = QtWidgets.QHBoxLayout()
         btns.addWidget(self.start_btn)
         btns.addWidget(self.stop_btn)
+        btns.addWidget(self.skip_btn)
         btns.addStretch(1)
 
         v = QtWidgets.QVBoxLayout(self)
@@ -531,8 +589,10 @@ class MainWindow(QtWidgets.QWidget):
         # Signals
         self.start_btn.clicked.connect(self.on_start)
         self.stop_btn.clicked.connect(self.on_stop)
+        self.skip_btn.clicked.connect(self.on_skip)
         self.console_chk.toggled.connect(self.console.setVisible)
         self.res_combo.currentIndexChanged.connect(self.on_quality_change)
+        self.browse_btn.clicked.connect(self.on_browse_bumper)
 
         # persist as you tweak
         self.remember_chk.toggled.connect(lambda _: self.save_settings())
@@ -541,6 +601,7 @@ class MainWindow(QtWidgets.QWidget):
         self.res_combo.currentIndexChanged.connect(lambda _: self.save_settings())
         self.bitrate_edit.textChanged.connect(lambda _: self.save_settings())
         self.bufsize_edit.textChanged.connect(lambda _: self.save_settings())
+        self.bumper_edit.textChanged.connect(lambda _: self.save_settings())
 
         self.on_quality_change()
         self.load_settings()
@@ -568,6 +629,8 @@ class MainWindow(QtWidgets.QWidget):
             self.bitrate_edit.setText(cfg["video_bitrate"])
         if "bufsize" in cfg:
             self.bufsize_edit.setText(cfg["bufsize"])
+        if "bumper_path" in cfg:
+            self.bumper_edit.setText(cfg["bumper_path"])
 
     def save_settings(self):
         data = load_config_json()
@@ -578,6 +641,7 @@ class MainWindow(QtWidgets.QWidget):
             "quality": self.res_combo.currentText(),
             "video_bitrate": self.bitrate_edit.text().strip(),
             "bufsize": self.bufsize_edit.text().strip(),
+            "bumper_path": self.bumper_edit.text().strip(),
         })
         if self.remember_chk.isChecked():
             data["playlist_url"] = self.playlist_edit.text().strip()
@@ -596,9 +660,28 @@ class MainWindow(QtWidgets.QWidget):
         self.console.append(text)
         self.console.moveCursor(QtGui.QTextCursor.End)
 
+    def on_browse_bumper(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select bumper video",
+            "",
+            "Video Files (*.mp4 *.mkv *.mov *.avi);;All Files (*)",
+        )
+        if path:
+            self.bumper_edit.setText(path)
+            self.save_settings()
+
     def on_quality_change(self):
         choice = self.res_combo.currentText()
-        if "720p30" in choice:
+        if "480p30" in choice:
+            self._fps = 30; self._height = 480
+            if not self.streaming:
+                self.bitrate_edit.setText("1000k"); self.bufsize_edit.setText("2000k")
+        elif "480p60" in choice:
+            self._fps = 60; self._height = 480
+            if not self.streaming:
+                self.bitrate_edit.setText("1500k"); self.bufsize_edit.setText("3000k")
+        elif "720p30" in choice:
             self._fps = 30; self._height = 720
             if not self.streaming:
                 self.bitrate_edit.setText("2300k"); self.bufsize_edit.setText("4600k")
@@ -606,10 +689,14 @@ class MainWindow(QtWidgets.QWidget):
             self._fps = 60; self._height = 720
             if not self.streaming:
                 self.bitrate_edit.setText("3200k"); self.bufsize_edit.setText("6400k")
-        else:  # 1080p30
+        elif "1080p30" in choice:
             self._fps = 30; self._height = 1080
             if not self.streaming:
                 self.bitrate_edit.setText("4500k"); self.bufsize_edit.setText("9000k")
+        else:  # 1080p60
+            self._fps = 60; self._height = 1080
+            if not self.streaming:
+                self.bitrate_edit.setText("6000k"); self.bufsize_edit.setText("12000k")
 
     def make_config(self) -> StreamConfig:
         return StreamConfig(
@@ -622,9 +709,10 @@ class MainWindow(QtWidgets.QWidget):
             audio_bitrate="128k",
             overlay_titles=self.overlay_chk.isChecked(),
             shuffle=self.shuffle_chk.isChecked(),
-            sleep_between=3,
+            sleep_between=0,
             fontfile=r"C:\Windows\Fonts\arial.ttf",
             title_file="current_title.txt",
+            bumper_path=self.bumper_edit.text().strip(),
         )
 
     # --- start/stop wiring ---
@@ -642,6 +730,7 @@ class MainWindow(QtWidgets.QWidget):
         self.streaming = True
         self.start_btn.setEnabled(False)
         self.stop_btn.setEnabled(True)
+        self.skip_btn.setEnabled(True)
         self.append_log("[INFO] Starting stream…")
 
         self.worker_thread = QtCore.QThread(self)
@@ -675,6 +764,16 @@ class MainWindow(QtWidgets.QWidget):
 
         # Do not quit the thread here; let on_finished() handle cleanup
         self.stop_btn.setEnabled(False)
+        self.skip_btn.setEnabled(False)
+
+    def on_skip(self):
+        if not self.streaming or not self.worker:
+            return
+        self.append_log("[INFO] Skipping…")
+        try:
+            self.worker.skip()
+        except Exception:
+            pass
 
     def on_finished(self):
         self.append_log("[INFO] Worker finished.")
@@ -689,6 +788,7 @@ class MainWindow(QtWidgets.QWidget):
         self.streaming = False
         self.start_btn.setEnabled(True)
         self.stop_btn.setEnabled(False)
+        self.skip_btn.setEnabled(False)
 
 # ---------- entry ----------
 def main():


### PR DESCRIPTION
## Summary
- allow skipping current video without stopping the stream
- expand quality presets up to 1080p60 and adjust bitrates
- remove inter-video delay so playlists switch immediately or via optional bumper

## Testing
- `python -m py_compile Stream247_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10dd33bb08332bf6f94fb77b208e2