### PR TITLE
Use combo box lookup for quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ cython_debug/
 .cursorindexingignore
 *.txt
 *.json
+ffmpeg.exe
+yt-dlp.exe

--- a/Stream247_GUI.py
+++ b/Stream247_GUI.py
@@ -603,11 +603,9 @@ class MainWindow(QtWidgets.QWidget):
         self.shuffle_chk.setChecked(bool(cfg.get("shuffle", False)))
 
         if "quality" in cfg:
-            try:
-                idx = ["720p30 (stable)", "720p60", "1080p30"].index(cfg["quality"])
+            idx = self.res_combo.findText(cfg["quality"])
+            if idx >= 0:
                 self.res_combo.setCurrentIndex(idx)
-            except Exception:
-                pass
         if "video_bitrate" in cfg:
             self.bitrate_edit.setText(cfg["video_bitrate"])
         if "bufsize" in cfg:


### PR DESCRIPTION
## Summary
- Replace hard-coded quality list lookup with combo box findText
- Guard resolution assignment to ensure index is valid

## Testing
- `python -m py_compile Stream247_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1176032e8833284a88be1d94f810f