### PR TITLE
feat: allow configurable audio codec and bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Stream247 automatically encodes your videos using available hardware acceleratio
 
 * Stream any **public YouTube playlist** directly to YouTube Live  
 * Supports **1080p streaming** (configurable)  
-* Adjustable **bitrate** and **buffer size**  
+* Adjustable **video/audio bitrate**, **buffer size**, and **audio codec**
 * Options to:  
   * Overlay current VOD title  
   * Shuffle playlist order  


### PR DESCRIPTION
## Summary
- add audio codec and bitrate configuration fields to GUI
- pass chosen audio settings through StreamConfig to ffmpeg command
- persist audio codec/bitrate in config.json and document in README

## Testing
- `python -m py_compile Stream247_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68b11c56bfa8833297bc0e4e4554781b