### PR TITLE
Fix bumper playback after skips and add stream test option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ cython_debug/
 *.json
 ffmpeg.exe
 yt-dlp.exe
+Flow_Background.mp4

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Stream247 automatically encodes your videos using available hardware acceleratio
 
 * Stream any **public YouTube playlist** directly to YouTube Live  
 * Supports **1080p streaming** (configurable)  
-* Adjustable **bitrate** and **buffer size**  
-* Options to:  
-  * Overlay current VOD title  
-  * Shuffle playlist order  
-  * Save playlist & key to config file  
+* Adjustable **bitrate** and **buffer size**
+* Options to:
+  * Overlay current VOD title
+  * Shuffle playlist order
+  * Save playlist & key to config file
+* Test the playlist locally with your preferred video player
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Ensure bumper plays after skipping videos
- Allow testing the playlist through a user-selected local player
- Document new test playback feature

## Testing
- `python -m py_compile Stream247_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68b120e4b46c8332ba245d9b10c27321