### PR TITLE
Guard high-DPI policy when reusing Qt application

### DIFF
--- a/Stream247_GUI.py
+++ b/Stream247_GUI.py
@@ -845,9 +845,17 @@ def main():
     if IS_WIN:
         import ctypes
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(APP_NAME)
-
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
-    app = QtWidgets.QApplication(sys.argv)
+    
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+        try:
+            QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+                QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+            )
+        except AttributeError:
+            pass
+        app = QtWidgets.QApplication(sys.argv)
 
     # Load .ico (next to EXE when frozen, or cwd when running from source)
     icon = QtGui.QIcon(resource_path("icon.ico"))


### PR DESCRIPTION
## Summary
- Check for existing QApplication instance before setting DPI policies
- Set high-DPI scale factor rounding policy only when creating the application
- Ensure widgets are instantiated after QApplication creation

## Testing
- `python -m py_compile Stream247_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1f469842c8332a57dd39b3fa485d4