### PR TITLE
Add tabbed interface with stream controls and settings

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1,32 +1,171 @@
 const e = React.createElement;
 
 function App() {
+  const TABS = {
+    STREAM: 'stream',
+    CONSOLE: 'console',
+    SETTINGS: 'settings',
+    ABOUT: 'about'
+  };
+
+  const [activeTab, setActiveTab] = React.useState(TABS.STREAM);
+
+  // Settings state
+  const [quality, setQuality] = React.useState('720p');
+  const [bitrate, setBitrate] = React.useState('');
+  const [bufferSize, setBufferSize] = React.useState('');
+  const [overlayInfo, setOverlayInfo] = React.useState(false);
+  const [shuffleOrder, setShuffleOrder] = React.useState(false);
+  const [logToFile, setLogToFile] = React.useState(false);
   const [playlistUrl, setPlaylistUrl] = React.useState('');
   const [streamKey, setStreamKey] = React.useState('');
+  const [savePlaylist, setSavePlaylist] = React.useState(false);
+  const [saveStreamKey, setSaveStreamKey] = React.useState(false);
+
+  function renderTabButton(tab, label) {
+    return e('button', {
+      className: activeTab === tab ? 'tab active' : 'tab',
+      onClick: () => setActiveTab(tab)
+    }, label);
+  }
+
+  function renderStreamTab() {
+    return e('div', { className: 'tab-content' },
+      e('button', { onClick: () => console.log('Start') }, 'Start'),
+      e('button', { onClick: () => console.log('Stop') }, 'Stop'),
+      e('button', { onClick: () => console.log('Skip Video') }, 'Skip Video')
+    );
+  }
+
+  function renderConsoleTab() {
+    return e('pre', { className: 'tab-content console' }, 'Console output...');
+  }
+
+  function renderSettingsTab() {
+    return e('div', { className: 'tab-content settings' },
+      e('div', null,
+        e('label', null, 'Quality'),
+        e('select', {
+          value: quality,
+          onChange: ev => setQuality(ev.target.value)
+        }, [
+          e('option', { value: '480p' }, '480p'),
+          e('option', { value: '720p' }, '720p'),
+          e('option', { value: '1080p' }, '1080p')
+        ])
+      ),
+      e('div', null,
+        e('label', null, 'Video Bitrate'),
+        e('input', {
+          value: bitrate,
+          onChange: ev => setBitrate(ev.target.value)
+        })
+      ),
+      e('div', null,
+        e('label', null, 'Buffer Size'),
+        e('input', {
+          value: bufferSize,
+          onChange: ev => setBufferSize(ev.target.value)
+        })
+      ),
+      e('div', null,
+        e('label', null,
+          e('input', {
+            type: 'checkbox',
+            checked: overlayInfo,
+            onChange: ev => setOverlayInfo(ev.target.checked)
+          }),
+          ' Overlay current VOD title and date'
+        )
+      ),
+      e('div', null,
+        e('label', null,
+          e('input', {
+            type: 'checkbox',
+            checked: shuffleOrder,
+            onChange: ev => setShuffleOrder(ev.target.checked)
+          }),
+          ' Shuffle order'
+        )
+      ),
+      e('div', null,
+        e('label', null,
+          e('input', {
+            type: 'checkbox',
+            checked: logToFile,
+            onChange: ev => setLogToFile(ev.target.checked)
+          }),
+          ' Log to file'
+        )
+      ),
+      e('div', null,
+        e('label', null, 'Playlist URL'),
+        e('input', {
+          value: playlistUrl,
+          onChange: ev => setPlaylistUrl(ev.target.value)
+        })
+      ),
+      e('div', null,
+        e('label', null, 'Stream Key'),
+        e('input', {
+          value: streamKey,
+          onChange: ev => setStreamKey(ev.target.value)
+        })
+      ),
+      e('div', null,
+        e('label', null,
+          e('input', {
+            type: 'checkbox',
+            checked: savePlaylist,
+            onChange: ev => setSavePlaylist(ev.target.checked)
+          }),
+          ' Save playlist'
+        )
+      ),
+      e('div', null,
+        e('label', null,
+          e('input', {
+            type: 'checkbox',
+            checked: saveStreamKey,
+            onChange: ev => setSaveStreamKey(ev.target.checked)
+          }),
+          ' Save stream key'
+        )
+      ),
+      e('button', { onClick: () => console.log('Settings saved') }, 'Save Settings')
+    );
+  }
+
+  function renderAboutTab() {
+    return e('div', { className: 'tab-content about' }, 'Stream247 - simple streaming UI');
+  }
+
+  function renderActiveTab() {
+    switch (activeTab) {
+      case TABS.CONSOLE:
+        return renderConsoleTab();
+      case TABS.SETTINGS:
+        return renderSettingsTab();
+      case TABS.ABOUT:
+        return renderAboutTab();
+      case TABS.STREAM:
+      default:
+        return renderStreamTab();
+    }
+  }
 
   return e('div', { className: 'app' },
     e('h1', null, 'Stream247'),
-    e('div', null,
-      e('label', null, 'Playlist URL:'),
-      e('input', {
-        value: playlistUrl,
-        onChange: ev => setPlaylistUrl(ev.target.value)
-      })
+    e('div', { className: 'tabs' },
+      renderTabButton(TABS.STREAM, 'Stream'),
+      renderTabButton(TABS.CONSOLE, 'Console'),
+      renderTabButton(TABS.SETTINGS, 'Settings'),
+      renderTabButton(TABS.ABOUT, 'About')
     ),
-    e('div', null,
-      e('label', null, 'Stream Key:'),
-      e('input', {
-        value: streamKey,
-        onChange: ev => setStreamKey(ev.target.value)
-      })
-    ),
-    e('button', {
-      onClick: () => {
-        console.log('Start streaming not implemented');
-      }
-    }, 'Start Stream')
+    renderActiveTab()
   );
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(e(App));
+

--- a/styles.css
+++ b/styles.css
@@ -97,3 +97,48 @@ body {
     background-color: var(--button-hover-bg);
     box-shadow: 0 0 20px var(--card-shadow);
 }
+
+/* Tabs */
+.tabs {
+    display: flex;
+    margin-bottom: 1rem;
+}
+
+.tab {
+    flex: 1;
+    padding: 0.5rem;
+    background: var(--button-bg);
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    width: auto;
+}
+
+.tab:not(:last-child) {
+    margin-right: 0.25rem;
+}
+
+.tab.active {
+    background: var(--button-hover-bg);
+}
+
+.tab-content button {
+    margin-bottom: 0.5rem;
+}
+
+.tab-content.console {
+    background: var(--background-color);
+    padding: 0.5rem;
+    border: 1px solid var(--border-color);
+    min-height: 100px;
+}
+
+/* Select inputs */
+.app select {
+    padding: 0.75rem;
+    font-size: var(--font-size-base);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--background-color);
+    color: var(--text-color);
+}


### PR DESCRIPTION
## Summary
- implement Stream, Console, Settings, and About tabs
- add Start, Stop, and Skip Video buttons
- provide settings for quality, bitrate, buffer, overlay info, shuffle order, logging, playlist URL, and stream key

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2210eabcc8332a14322a932e4ec86