### PR TITLE
Optimize ffmpeg monitoring loop

### DIFF
--- a/Stream247_GUI.py
+++ b/Stream247_GUI.py
@@ -389,10 +389,12 @@ class StreamWorker(QtCore.QObject):
             readers.append(t)
 
         # Wait until ffmpeg finishes or a stop/skip is requested
-        while self.ff_proc and self.ff_proc.poll() is None and not (
-            self._stop.is_set() or self._skip.is_set()
-        ):
-            time.sleep(0.2)
+        while self.ff_proc and not (self._stop.is_set() or self._skip.is_set()):
+            try:
+                self.ff_proc.wait(timeout=0.2)
+                break  # process finished
+            except subprocess.TimeoutExpired:
+                continue
 
         if (self._stop.is_set() or self._skip.is_set()) and self.ff_proc and self.ff_proc.poll() is None:
             try:


### PR DESCRIPTION
## Summary
- use `Popen.wait` with a short timeout to avoid busy-waiting when waiting for ffmpeg to finish

## Testing
- `python -m py_compile Stream247_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68b22a5cc1d08332895eb98739b5f5bb