### PR TITLE
2.1.1

### DIFF
--- a/stream247/constants.py
+++ b/stream247/constants.py
@@ -3,7 +3,7 @@
 from typing import Dict, Tuple
 
 APP_NAME = "Stream247"  # Name shown in logs and dashboard
-APP_VERSION = "2.1"  # Current version
+APP_VERSION = "2.1.1"  # Current version
 GITHUB_REPO = "TheDoctorTTV/247-stream"  # GitHub repository for updates
 APP_UPDATE_MIN_VERSION = "2.0-pre-release-2"  # Oldest version eligible for in-app updater
 

--- a/stream247/worker.py
+++ b/stream247/worker.py
@@ -1593,24 +1593,20 @@ class StreamWorker(QtCore.QObject):
             if input_type in ('twitch_stream', 'direct_hls'):
                 # Twitch stream or direct HLS - continuous streaming
                 stream_type_name = "Twitch stream" if input_type == 'twitch_stream' else "HLS stream"
-                self.log.emit(f"[INFO] Detected {stream_type_name} - streaming continuously...")
+                self.log.emit(f"[INFO] Detected {stream_type_name} - streaming until source ends...")
                 while not self._stop.is_set():
                     try:
                         self.run_twitch_stream(self.cfg.playlist_url)
                         if not self._stop.is_set():
-                            self.log.emit(f"[WARN] {stream_type_name} ended unexpectedly. Reconnecting in 5s...")
-                            for _ in range(5):
-                                if self._stop.is_set():
-                                    break
-                                time.sleep(1)
+                            self.log.emit(f"[INFO] {stream_type_name} ended. Stopping relay.")
+                            self._stop.set()
+                            break
                     except Exception as e:
                         self.log.emit(f"[ERROR] {stream_type_name} error: {e}")
                         if not self._stop.is_set():
-                            self.log.emit("[INFO] Retrying in 10s...")
-                            for _ in range(10):
-                                if self._stop.is_set():
-                                    break
-                                time.sleep(1)
+                            self.log.emit("[INFO] Stopping relay due to source stream error.")
+                            self._stop.set()
+                            break
             else:
                 if self._use_persistent_rtmp_bridge():
                     if not self._start_rtmp_bridge():

--- a/updates/CHANGELOG-2.1.1.md
+++ b/updates/CHANGELOG-2.1.1.md
@@ -1,0 +1,13 @@
+# Stream247 v2.1.1 Changelog
+
+## Summary
+v2.1.1 changes relay-session behavior so incoming live relays stop cleanly when the upstream stream ends, instead of auto-reconnecting.
+
+## Changed
+- Relay mode for Twitch URL and direct HLS `.m3u8` sources no longer auto-reconnects after source end.
+- Relay mode now stops the worker session when the source stream ends.
+- Relay mode now stops the worker session on source stream errors instead of retrying in a reconnect loop.
+
+## Notes
+- This behavior applies to relay-style live inputs (`twitch_stream`, `direct_hls`) only.
+- YouTube playlist/video loop behavior is unchanged.


### PR DESCRIPTION
# Stream247 v2.1.1 Changelog

## Summary
v2.1.1 changes relay-session behavior so incoming live relays stop cleanly when the upstream stream ends, instead of auto-reconnecting.

## Changed
- Relay mode for Twitch URL and direct HLS `.m3u8` sources no longer auto-reconnects after source end.
- Relay mode now stops the worker session when the source stream ends.
- Relay mode now stops the worker session on source stream errors instead of retrying in a reconnect loop.

## Notes
- This behavior applies to relay-style live inputs (`twitch_stream`, `direct_hls`) only.
- YouTube playlist/video loop behavior is unchanged.
